### PR TITLE
fix: 로그아웃 시 localstorage에서 rememberMe를 삭제하도록 수정

### DIFF
--- a/netflix/src/utils/auth/authService.js
+++ b/netflix/src/utils/auth/authService.js
@@ -57,6 +57,7 @@ export default class AuthService {
   logout() {
     localStorage.removeItem("currentUser");
     localStorage.removeItem("isLoggedIn");
+    localStorage.removeItem("rememberMe");
     console.log("로그아웃 완료!");
   }
 }


### PR DESCRIPTION
## Overview
- 로그아웃 상태에서도 rememberme가 남아있어 영화 리스트를 가져오는 오류를 수정

## Change Log
- 로그아웃할 경우 localstorage의 rememberme를 삭제

## Issue Tags
- Closed: #29 