### PR TITLE
feat: wishlist 페이지 구현

### DIFF
--- a/netflix/src/component/MovieCard.jsx
+++ b/netflix/src/component/MovieCard.jsx
@@ -1,5 +1,7 @@
-import React, { useState } from "react";
+import React from "react";
 import styled from "styled-components";
+import { useSelector, useDispatch } from "react-redux";
+import { toggleWishlist } from "../redux/wishlistSlice";
 
 const MovieCardContainer = styled.div`
   flex: 0 0 auto;
@@ -53,10 +55,10 @@ const HeartButton = styled.button`
   position: absolute;
   top: 8px;
   right: 8px;
-  background: rgba(255, 255, 255, 0.2); /* 흰색 반투명 배경 */
+  background: rgba(255, 255, 255, 0.2);
   border: none;
   border-radius: 50%;
-  width: 28px; /* 크기를 작게 조정 */
+  width: 28px;
   height: 28px;
   display: flex;
   justify-content: center;
@@ -77,22 +79,24 @@ const HeartButton = styled.button`
   & > svg {
     width: 16px;
     height: 16px;
-    fill: ${(props) => (props.isLiked ? "var(--primary-color)" : "var(--white-24dp)")}; /* 하트 색상 */
-    stroke-width: 1px; /* 외곽선 두께 */
+    fill: ${(props) => (props.isLiked ? "var(--primary-color)" : "var(--white-24dp)")};
+    stroke-width: 1px;
     transition: fill 0.3s ease, stroke 0.3s ease;
   }
 
   &:hover > svg {
-    fill: ${(props) => (props.isLiked ? "var(--primary-color)" : "rgba(220, 37, 31, 0.3)")}; /* hover 상태에서 분홍색 */
+    fill: ${(props) => (props.isLiked ? "var(--primary-color)" : "rgba(220, 37, 31, 0.3)")};
   }
 `;
 
-
 const MovieCard = ({ movie }) => {
-  const [isLiked, setIsLiked] = useState(false);
+  const wishlist = useSelector((state) => state.wishlist.wishlist);
+  const dispatch = useDispatch();
+
+  const isLiked = wishlist.some((item) => item.id === movie.id);
 
   const toggleLike = () => {
-    setIsLiked((prev) => !prev);
+    dispatch(toggleWishlist(movie));
   };
 
   return (

--- a/netflix/src/component/MovieCard.jsx
+++ b/netflix/src/component/MovieCard.jsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { useSelector, useDispatch } from "react-redux";
 import { toggleWishlist } from "../redux/wishlistSlice";
+import movieListService from "../service/movieListService.js";
 
 const MovieCardContainer = styled.div`
   flex: 0 0 auto;
@@ -90,6 +91,7 @@ const HeartButton = styled.button`
 `;
 
 const MovieCard = ({ movie }) => {
+  const [genreNames, setGenreNames] = useState([]);
   const wishlist = useSelector((state) => state.wishlist.wishlist);
   const dispatch = useDispatch();
 
@@ -98,6 +100,20 @@ const MovieCard = ({ movie }) => {
   const toggleLike = () => {
     dispatch(toggleWishlist(movie));
   };
+
+  useEffect(() => {
+    const fetchGenres = async () => {
+      try {
+        const genreMapping = await movieListService.fetchGenreMapping();
+        const mappedGenres = movie.genre_ids.map((id) => genreMapping[id] || "Unknown");
+        setGenreNames(mappedGenres);
+      } catch (error) {
+        console.error("Error fetching genres:", error);
+      }
+    };
+
+    fetchGenres();
+  }, [movie.genre_ids]);
 
   return (
     <MovieCardContainer
@@ -114,7 +130,7 @@ const MovieCard = ({ movie }) => {
         <InfoText>{movie.title}</InfoText>
         <InfoText>평점: {movie.vote_average}</InfoText>
         <InfoText>개봉일: {movie.release_date}</InfoText>
-        <InfoText>장르: {movie.genre_names?.join(", ") || "정보 없음"}</InfoText>
+        <InfoText>장르: {genreNames.join(", ") || "정보 없음"}</InfoText>
       </Overlay>
     </MovieCardContainer>
   );

--- a/netflix/src/component/MovieCard.jsx
+++ b/netflix/src/component/MovieCard.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+import styled from "styled-components";
+
+const MovieCardContainer = styled.div`
+  flex: 0 0 auto;
+  width: 200px;
+  height: 300px;
+  border-radius: 10px;
+  background-size: cover;
+  background-position: center;
+  scroll-snap-align: start;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+
+  &:hover {
+    transform: scale(1.05);
+    box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.2);
+  }
+
+  &:hover > div {
+    opacity: 1;
+  }
+`;
+
+const Overlay = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background: var(--white-01dp);
+  backdrop-filter: blur(10px);
+  border: 1px solid var(--white-03dp);
+  border-radius: 10px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+`;
+
+const InfoText = styled.div`
+  color: #fff;
+  text-align: center;
+  font-size: 14px;
+  margin: 5px 0;
+  text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
+`;
+
+const MovieCard = ({ movie }) => {
+  return (
+    <MovieCardContainer
+      style={{
+        backgroundImage: `url(https://image.tmdb.org/t/p/w500${movie.poster_path})`,
+      }}
+    >
+      <Overlay>
+        <InfoText>{movie.title}</InfoText>
+        <InfoText>평점: {movie.vote_average}</InfoText>
+        <InfoText>개봉일: {movie.release_date}</InfoText>
+        <InfoText>장르: {movie.genre_names?.join(", ") || "정보 없음"}</InfoText>
+      </Overlay>
+    </MovieCardContainer>
+  );
+};
+
+export default MovieCard;

--- a/netflix/src/component/MovieCard.jsx
+++ b/netflix/src/component/MovieCard.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 
 const MovieCardContainer = styled.div`
@@ -49,13 +49,63 @@ const InfoText = styled.div`
   text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
 `;
 
+const HeartButton = styled.button`
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: rgba(255, 255, 255, 0.2); /* 흰색 반투명 배경 */
+  border: none;
+  border-radius: 50%;
+  width: 28px; /* 크기를 작게 조정 */
+  height: 28px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  z-index: 5;
+  transition: transform 0.3s ease, background-color 0.3s ease;
+
+  &:hover {
+    transform: scale(1.1);
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  & > svg {
+    width: 16px;
+    height: 16px;
+    fill: ${(props) => (props.isLiked ? "var(--primary-color)" : "var(--white-24dp)")}; /* 하트 색상 */
+    stroke-width: 1px; /* 외곽선 두께 */
+    transition: fill 0.3s ease, stroke 0.3s ease;
+  }
+
+  &:hover > svg {
+    fill: ${(props) => (props.isLiked ? "var(--primary-color)" : "rgba(220, 37, 31, 0.3)")}; /* hover 상태에서 분홍색 */
+  }
+`;
+
+
 const MovieCard = ({ movie }) => {
+  const [isLiked, setIsLiked] = useState(false);
+
+  const toggleLike = () => {
+    setIsLiked((prev) => !prev);
+  };
+
   return (
     <MovieCardContainer
       style={{
         backgroundImage: `url(https://image.tmdb.org/t/p/w500${movie.poster_path})`,
       }}
     >
+      <HeartButton isLiked={isLiked} onClick={toggleLike}>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+          <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 6 4 4 6.5 4c1.74 0 3.41.81 4.5 2.09C12.09 4.81 13.76 4 15.5 4 18 4 20 6 20 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+        </svg>
+      </HeartButton>
       <Overlay>
         <InfoText>{movie.title}</InfoText>
         <InfoText>평점: {movie.vote_average}</InfoText>

--- a/netflix/src/feature/SignInUI.jsx
+++ b/netflix/src/feature/SignInUI.jsx
@@ -259,6 +259,7 @@ const SignInUI = () => {
 
   return (
     <Container>
+      <div style={{ marginTop: "80px" }} />
       <Welcome>
         <FormBox isSignUp={isSignUp}>
           <FormContainer isHidden={!isSignUp}>

--- a/netflix/src/feature/movieListCarousel.jsx
+++ b/netflix/src/feature/movieListCarousel.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from "react";
 import styled from "styled-components";
-import movieListService from "../service/movieListService.js"; // 영화 데이터를 가져오는 서비스
+import MovieCard from "../component/MovieCard.jsx";
 
 const ArrowButton = styled.button`
   position: absolute;
@@ -72,54 +72,6 @@ const CarouselContent = styled.div`
   }
 `;
 
-const MovieCard = styled.div`
-  flex: 0 0 auto;
-  width: 200px;
-  height: 300px;
-  border-radius: 10px;
-  background-size: cover;
-  background-position: center;
-  scroll-snap-align: start;
-  position: relative;
-  overflow: hidden;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-
-  &:hover {
-    transform: scale(1.05);
-    box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.2);
-  }
-
-  &:hover > div {
-    opacity: 1;
-  }
-`;
-
-const Overlay = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  background: var(--white-01dp);
-  backdrop-filter: blur(10px);
-  border: 1px solid var(--white-03dp);
-  border-radius: 10px;
-  opacity: 0;
-  transition: opacity 0.3s ease;
-`;
-
-const InfoText = styled.div`
-  color: #fff;
-  text-align: center;
-  font-size: 14px;
-  margin: 5px 0;
-  text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
-`;
-
 const MovieListCarousel = ({ fetchMovies, title }) => {
   const [movies, setMovies] = useState([]);
   const carouselRef = useRef(null);
@@ -133,9 +85,9 @@ const MovieListCarousel = ({ fetchMovies, title }) => {
         console.error("Failed to load movies:", error);
       }
     };
-  
+
     loadMovies();
-  }, [fetchMovies]); // fetchMovies 의존성 추가
+  }, [fetchMovies]);
 
   const slide = (direction) => {
     if (carouselRef.current) {
@@ -166,19 +118,7 @@ const MovieListCarousel = ({ fetchMovies, title }) => {
       </ArrowButton>
       <CarouselContent ref={carouselRef}>
         {movies.map((movie) => (
-          <MovieCard
-            key={movie.id}
-            style={{
-              backgroundImage: `url(https://image.tmdb.org/t/p/w500${movie.poster_path})`,
-            }}
-          >
-            <Overlay>
-              <InfoText>{movie.title}</InfoText>
-              <InfoText>평점: {movie.vote_average}</InfoText>
-              <InfoText>개봉일: {movie.release_date}</InfoText>
-              <InfoText>장르: {movie.genre_names?.join(", ") || "정보 없음"}</InfoText>
-            </Overlay>
-          </MovieCard>
+          <MovieCard key={movie.id} movie={movie} />
         ))}
       </CarouselContent>
       <ArrowButton className="right" onClick={() => slide("right")}>

--- a/netflix/src/layout/NavBar.jsx
+++ b/netflix/src/layout/NavBar.jsx
@@ -177,7 +177,8 @@ function NavBar() {
           )}
         </LoginTab>
       </NavBarContainer>
-      <div style={{ marginTop: "55px" }} /> {/* 네비게이션 바 높이만큼 페이지 콘텐츠 간격 추가 */}
+      {/* 로그인 상태일 때만 렌더링 */}
+      {isLoggedIn && <div style={{ marginTop: "55px" }} />}
     </>
   );
 }

--- a/netflix/src/layout/TopButton.jsx
+++ b/netflix/src/layout/TopButton.jsx
@@ -1,0 +1,65 @@
+import React, { useState, useEffect } from "react";
+import styled from "styled-components";
+
+const Button = styled.button`
+  position: fixed;
+  bottom: 30px;
+  right: 30px;
+  width: 50px;
+  height: 50px;
+  background-color: var(--primary-color, #007bff);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  opacity: ${(props) => (props.visible ? 1 : 0)};
+  transform: ${(props) => (props.visible ? "translateY(0)" : "translateY(20px)")};
+  pointer-events: ${(props) => (props.visible ? "auto" : "none")};
+  transition: opacity 0.3s ease, transform 0.3s ease;
+
+  &:hover {
+    background-color: var(--primary-color, #0056b3);
+    transform: scale(1.1);
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  svg {
+    width: 24px;
+    height: 24px;
+    fill: white;
+  }
+`;
+
+const TopButton = () => {
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  const handleScroll = () => {
+    // 스크롤 여부만 확인
+    setIsScrolled(window.scrollY > 0);
+  };
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  return (
+    <Button visible={isScrolled} onClick={scrollToTop}>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+        <path d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.59 5.58L20 12l-8-8-8 8z" />
+      </svg>
+    </Button>
+  );
+};
+
+export default TopButton;

--- a/netflix/src/pages/LogoutMain.jsx
+++ b/netflix/src/pages/LogoutMain.jsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { useNavigate } from "react-router-dom"; // React Router 사용
+import styled from "styled-components";
+import TVRed from "../assets/img/TVRed.png"; // 이미지 가져오기
+
+// PlayButton 스타일 정의
+const PlayButton = styled.button`
+  background: var(--primary-color);
+  color: var(--basic-font);
+  font-size: 18px;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  transition: all 0.3s ease;
+
+  &:hover {
+    background: transparent; /* 배경색 제거 */
+    color: var(--primary-color); /* 텍스트 색상 변경 */
+    transform: scale(1.05); /* 크기 증가 효과 */
+  }
+
+  &:active {
+    transform: scale(0.98); /* 클릭 시 크기 감소 효과 */
+  }
+`;
+
+function LogoutMain() {
+  const navigate = useNavigate(); // 페이지 이동 함수
+
+  const handleLogin = () => {
+    navigate("/signin"); // "/signin" 페이지로 이동
+  };
+
+  return (
+    <div
+      style={{
+        backgroundImage: `linear-gradient(
+          rgba(0, 0, 0, 0.7),
+          rgba(0, 0, 0, 0.7)
+        ), url(${TVRed})`, // 배경 이미지 및 그라데이션 추가
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+        height: "100vh",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        flexDirection: "column",
+        color: "#fff",
+        textAlign: "center",
+      }}
+    >
+      <div
+        style={{
+          transform: "translateY(-35px)", // 텍스트와 버튼 위로 이동
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: "20px", // 텍스트와 버튼 사이 간격 조정
+        }}
+      >
+        {/* 중앙 텍스트 */}
+        <h1 style={{ fontSize: "3rem", marginBottom: "10px", color: "var(--basic-font)" }}>See What's Next</h1>
+        {/* 로그인 버튼 */}
+        <PlayButton onClick={handleLogin}>로그인하기</PlayButton>
+      </div>
+    </div>
+  );
+}
+
+export default LogoutMain;

--- a/netflix/src/pages/Main.jsx
+++ b/netflix/src/pages/Main.jsx
@@ -1,28 +1,43 @@
-import React from 'react';
-import ShowVideo from '../feature/ShowVideo.jsx';
+import React, { useState, useEffect } from "react";
+import ShowVideo from "../feature/ShowVideo.jsx";
 import MovieListCarousel from "../feature/movieListCarousel.jsx";
 import movieListService from "../service/movieListService";
+import LogoutMain from "../pages/LogoutMain.jsx"; // 로그인 페이지 컴포넌트
 
 function Main() {
+  const [isLoggedIn, setIsLoggedIn] = useState(false); // 로그인 상태 관리
+
+  useEffect(() => {
+    // localStorage에서 로그인 상태 확인
+    const loggedIn = localStorage.getItem("isLoggedIn") === "true";
+    setIsLoggedIn(loggedIn);
+  }, []); // 컴포넌트가 처음 렌더링될 때 실행
 
   const movieId = 912649; // Venom: The Last Dance의 TMDB 영화 ID
+
+  if (!isLoggedIn) {
+    // 로그인 상태가 아닐 경우 로그인 페이지 렌더링
+    return <LogoutMain />;
+  }
+
+  // 로그인 상태일 경우 메인 페이지 렌더링
   return (
     <div>
       <ShowVideo movieId={movieId} />
-        <div style={{ backgroundColor: "#121212", minHeight: "100vh", paddingBottom: "20px" }}>
-          <MovieListCarousel
-            title="인기 영화"
-            fetchMovies={() => movieListService.fetchPopularMovies(1)}
-          />
-          <MovieListCarousel
-            title="최신 영화"
-            fetchMovies={() => movieListService.fetchReleaseMovies(1)}
-          />
-          <MovieListCarousel
-            title="액션 영화"
-            fetchMovies={() => movieListService.fetchGenreMovies("28", 1)}
-          />
-        </div>
+      <div style={{ backgroundColor: "#121212", minHeight: "100vh", paddingBottom: "20px" }}>
+        <MovieListCarousel
+          title="인기 영화"
+          fetchMovies={() => movieListService.fetchPopularMovies(1)}
+        />
+        <MovieListCarousel
+          title="최신 영화"
+          fetchMovies={() => movieListService.fetchReleaseMovies(1)}
+        />
+        <MovieListCarousel
+          title="액션 영화"
+          fetchMovies={() => movieListService.fetchGenreMovies("28", 1)}
+        />
+      </div>
     </div>
   );
 }

--- a/netflix/src/pages/WishList.jsx
+++ b/netflix/src/pages/WishList.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { useSelector } from "react-redux";
 import MovieCard from "../component/MovieCard.jsx";
+import TopButton from "../layout/TopButton.jsx"; // TopButton import
 
 const WishListContainer = styled.div`
   padding: 20px;
@@ -34,7 +35,6 @@ const EmptyMessage = styled.div`
 `;
 
 const WishList = () => {
-  // Redux 상태 구독
   const wishlist = useSelector((state) => state.wishlist.wishlist);
 
   return (
@@ -49,6 +49,7 @@ const WishList = () => {
           ))}
         </GridContainer>
       )}
+      <TopButton /> {/* TopButton 컴포넌트 추가 */}
     </WishListContainer>
   );
 };

--- a/netflix/src/pages/WishList.jsx
+++ b/netflix/src/pages/WishList.jsx
@@ -1,0 +1,56 @@
+import React from "react";
+import styled from "styled-components";
+import { useSelector } from "react-redux";
+import MovieCard from "../component/MovieCard.jsx";
+
+const WishListContainer = styled.div`
+  padding: 20px;
+  max-width: 84%;
+  margin: 0 auto;
+`;
+
+const Banner = styled.div`
+  font-size: 32px;
+  font-weight: bold;
+  text-align: left;
+  color: var(--basic-font);
+  padding: 20px;
+  margin-bottom: 20px;
+  margin-top: 10px;
+`;
+
+const GridContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 16px;
+  padding: 20px;
+`;
+
+const EmptyMessage = styled.div`
+  text-align: center;
+  font-size: 18px;
+  color: #777;
+  margin-top: 40px;
+`;
+
+const WishList = () => {
+  // Redux 상태 구독
+  const wishlist = useSelector((state) => state.wishlist.wishlist);
+
+  return (
+    <WishListContainer>
+      <Banner>내가 찜한 리스트</Banner>
+      {wishlist.length === 0 ? (
+        <EmptyMessage>찜한 영화가 없습니다.</EmptyMessage>
+      ) : (
+        <GridContainer>
+          {wishlist.map((movie) => (
+            <MovieCard key={movie.id} movie={movie} />
+          ))}
+        </GridContainer>
+      )}
+    </WishListContainer>
+  );
+};
+
+export default WishList;

--- a/netflix/src/redux/authSlice.js
+++ b/netflix/src/redux/authSlice.js
@@ -20,6 +20,8 @@ const authSlice = createSlice({
       state.currentUser = null;
       localStorage.removeItem("isLoggedIn");
       localStorage.removeItem("currentUser");
+      localStorage.removeItem("rememberMe");
+      localStorage.removeItem("TMDb-Key");
     },
   },
 });

--- a/netflix/src/redux/store.js
+++ b/netflix/src/redux/store.js
@@ -1,9 +1,11 @@
 // src/redux/store.js
 import { configureStore } from "@reduxjs/toolkit";
 import authReducer from "./authSlice.js";
+import wishlistReducer from "./wishlistSlice.js";
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
+    wishlist: wishlistReducer,
   },
 });

--- a/netflix/src/redux/wishlistSlice.js
+++ b/netflix/src/redux/wishlistSlice.js
@@ -1,0 +1,33 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  wishlist: JSON.parse(localStorage.getItem("movieWishlist")) || [],
+};
+
+const wishlistSlice = createSlice({
+  name: "wishlist",
+  initialState,
+  reducers: {
+    toggleWishlist(state, action) {
+      const movie = action.payload;
+      const index = state.wishlist.findIndex((item) => item.id === movie.id);
+
+      if (index === -1) {
+        // 영화가 위시리스트에 없으면 추가
+        state.wishlist.push(movie);
+      } else {
+        // 영화가 이미 위시리스트에 있으면 제거
+        state.wishlist = state.wishlist.filter((item) => item.id !== movie.id);
+      }
+
+      // 로컬 스토리지 업데이트
+      localStorage.setItem("movieWishlist", JSON.stringify(state.wishlist));
+    },
+    initializeWishlist(state) {
+      state.wishlist = JSON.parse(localStorage.getItem("movieWishlist")) || [];
+    },
+  },
+});
+
+export const { toggleWishlist, initializeWishlist } = wishlistSlice.actions;
+export default wishlistSlice.reducer;

--- a/netflix/src/utils/auth/authService.js
+++ b/netflix/src/utils/auth/authService.js
@@ -58,6 +58,7 @@ export default class AuthService {
     localStorage.removeItem("currentUser");
     localStorage.removeItem("isLoggedIn");
     localStorage.removeItem("rememberMe");
+    localStorage.removeItem("TMDb-Key");
     console.log("로그아웃 완료!");
   }
 }


### PR DESCRIPTION
## Overview
![image](https://github.com/user-attachments/assets/893892e4-8577-4f8f-8f80-b048e5228143)
![image](https://github.com/user-attachments/assets/3b82311d-e3ff-494b-be24-ea4f30efe855)


## Change Log
- 로그아웃 상태의 main 페이지 구현
- 영화 포스터를 MovieCard 컴포넌트로 분리
- 영화 포스터에 좋아요 버튼 기능 구현
- redux를 이용해 wishlist 관리
- localstorage에 있는 wishlist 정보를 이용해 wishlist 페이지를 grid 로 구현
- infinity scroll을 위한 top button 구현

## Issue Tags
- Closed: #31 